### PR TITLE
Added a missing module that was required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project is a chatbot that can interact with users based on custom data. The
   - Imports: Flask, render_template, jsonify, request
 - OpenAI: `pip install openai`
 - Pyaudio: `pip install pyaudio`
-- Langchain: `pip install langchain, langchain-community`
+- Langchain: `pip install langchain, langchain-community`, `pip install -qU langchain-text-splitters`
 ## Other imports
 - OS
 - Audioop


### PR DESCRIPTION
The module 'langchain_text_splitters' is required to run the website and was not included inside the `langchain` or `langchain-community` modules. Added the required pip command to insure that the project runs